### PR TITLE
Make sure page URLs are set globally for GA

### DIFF
--- a/packages/launcher-component/src/analytics/google-analytics.ts
+++ b/packages/launcher-component/src/analytics/google-analytics.ts
@@ -25,7 +25,8 @@ export class GoogleAnalytics implements Analytics {
     }
 
     pageview(path: string) {
-        ga('send', 'pageview', path);
+        ga('set', 'page', path);
+        ga('send', 'pageview');
     }
 
     event(category: string, action: string, label?: string, value?: number, params?: object) {


### PR DESCRIPTION
This makes sure that GA can associate later events with the page they happened in.